### PR TITLE
Add option to disable Dynatrace metadata enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The `DefaultDimensions` field can be used to optionally specify a list of key/va
 
 #### DisableDynatraceMetadataEnrichment
 
-The `DisableDynatraceMetadataEnrichment` can be used to disable the Dynatrace metadata detection described below.
+The `DisableDynatraceMetadataEnrichment` option can be used to disable the Dynatrace metadata detection described below.
 
 ## Dynatrace Metadata Enrichment
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ The `Prefix` field specifies an optional prefix, which is prepended to each metr
 
 The `DefaultDimensions` field can be used to optionally specify a list of key/value pairs, which will be added as additional labels/dimensions to all data points.
 
+#### DisableOneAgentMetadataEnrichment
+
+The `DisableOneAgentMetadataEnrichment` can be used to disable the OneAgent metadata detection described below.
+
 ## OneAgent Metadata Enrichment
 
 If running on a host with a running OneAgent, the exporter will export metadata collected by the OneAgent to the Dynatrace endpoint.

--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ The `Prefix` field specifies an optional prefix, which is prepended to each metr
 
 The `DefaultDimensions` field can be used to optionally specify a list of key/value pairs, which will be added as additional labels/dimensions to all data points.
 
-#### DisableOneAgentMetadataEnrichment
+#### DisableDynatraceMetadataEnrichment
 
-The `DisableOneAgentMetadataEnrichment` can be used to disable the OneAgent metadata detection described below.
+The `DisableDynatraceMetadataEnrichment` can be used to disable the Dynatrace metadata detection described below.
 
-## OneAgent Metadata Enrichment
+## Dynatrace Metadata Enrichment
 
 If running on a host with a running OneAgent, the exporter will export metadata collected by the OneAgent to the Dynatrace endpoint.
 This typically consists of the Dynatrace host ID and process group ID.

--- a/dynatrace/dynatrace.go
+++ b/dynatrace/dynatrace.go
@@ -48,10 +48,11 @@ func NewExporter(opts Options) (*Exporter, error) {
 
 	client := &http.Client{}
 
-	staticDimensions := dimensions.MergeLists(
-		dimensions.NewNormalizedDimensionList(dimensions.NewDimension("dt.metrics.source", "opentelemetry")),
-		oneagentenrichment.GetOneAgentMetadata(),
-	)
+	staticDimensions := dimensions.NewNormalizedDimensionList(dimensions.NewDimension("dt.metrics.source", "opentelemetry"))
+
+	if !opts.DisableOneAgentMetadataEnrichment {
+		staticDimensions = dimensions.MergeLists(staticDimensions, oneagentenrichment.GetOneAgentMetadata())
+	}
 
 	defaultDimensions := dimensions.NewNormalizedDimensionList(opts.DefaultDimensions...)
 
@@ -66,11 +67,12 @@ func NewExporter(opts Options) (*Exporter, error) {
 
 // Options contains options for configuring the exporter.
 type Options struct {
-	URL               string
-	APIToken          string
-	Prefix            string
-	DefaultDimensions []dimensions.Dimension
-	Logger            *zap.Logger
+	URL                               string
+	APIToken                          string
+	Prefix                            string
+	DefaultDimensions                 []dimensions.Dimension
+	Logger                            *zap.Logger
+	DisableOneAgentMetadataEnrichment bool
 
 	MetricNameFormatter func(namespace, name string) string
 }

--- a/dynatrace/dynatrace.go
+++ b/dynatrace/dynatrace.go
@@ -50,7 +50,7 @@ func NewExporter(opts Options) (*Exporter, error) {
 
 	staticDimensions := dimensions.NewNormalizedDimensionList(dimensions.NewDimension("dt.metrics.source", "opentelemetry"))
 
-	if !opts.DisableOneAgentMetadataEnrichment {
+	if !opts.DisableDynatraceMetadataEnrichment {
 		staticDimensions = dimensions.MergeLists(staticDimensions, oneagentenrichment.GetOneAgentMetadata())
 	}
 
@@ -67,12 +67,12 @@ func NewExporter(opts Options) (*Exporter, error) {
 
 // Options contains options for configuring the exporter.
 type Options struct {
-	URL                               string
-	APIToken                          string
-	Prefix                            string
-	DefaultDimensions                 []dimensions.Dimension
-	Logger                            *zap.Logger
-	DisableOneAgentMetadataEnrichment bool
+	URL                                string
+	APIToken                           string
+	Prefix                             string
+	DefaultDimensions                  []dimensions.Dimension
+	Logger                             *zap.Logger
+	DisableDynatraceMetadataEnrichment bool
 
 	MetricNameFormatter func(namespace, name string) string
 }


### PR DESCRIPTION
The option is to disable because in go there is no way to tell the difference between unset and false.